### PR TITLE
Disable auto update feature until it gets a user preference

### DIFF
--- a/src/chrome/content/sage.js
+++ b/src/chrome/content/sage.js
@@ -301,7 +301,7 @@ var sidebarController = {
       SageUpdateChecker.startCheck(aFolderId);
     } else {
       SageUpdateChecker.startCheck(SageUtils.getSageRootFolderId());
-      SageUpdateChecker.resetTimer();
+//       SageUpdateChecker.resetTimer();
     }
     SageMetrics.event("Sidebar", "Check Feeds");
   },

--- a/src/modules/SageUpdateChecker.jsm
+++ b/src/modules/SageUpdateChecker.jsm
@@ -50,8 +50,8 @@ var loader = Cc["@mozilla.org/moz/jssubscript-loader;1"]
              .getService(Ci.mozIJSSubScriptLoader);
 loader.loadSubScript("chrome://sage/content/commonfunc.js");
 
-const DELAY = 60 * 60 * 1000; // One hour between each check
-const INITIAL_CHECK = 5 * 1000; // Delay the first check to avoid impacting startup performance
+// const DELAY = 60 * 60 * 1000; // One hour between each check
+// const INITIAL_CHECK = 5 * 1000; // Delay the first check to avoid impacting startup performance
 const FEED_CHECK_TIMEOUT = 10 * 1000; // Wait up to ten seconds for a feed to load
 
 var SageUpdateChecker = {
@@ -82,35 +82,35 @@ var SageUpdateChecker = {
     var Logger = new Components.Constructor("@sage.mozdev.org/sage/logger;1", "sageILogger", "init");
     this.logger = new Logger();
 
-    this.initialCheck();
-    this.startTimer();
+//     this.initialCheck();
+//     this.startTimer();
     this._initialized = true;
     this.logger.info("update checker intialized");
   },
 
-  initialCheck: function() {
-    setTimeout((function () {
-      this.startCheck(SageUtils.getSageRootFolderId(), true);
-    }).bind(this), INITIAL_CHECK);
-  },
-
-  startTimer: function() {
-    if (this._timer) {
-      return;
-    }
-    setTimeout((function() {
-      this.startCheck(SageUtils.getSageRootFolderId(), true);
-      this.resetTimer();
-    }).bind(this), DELAY);
-  },
-
-  resetTimer: function() {
-    if (this._timer) {
-      clearTimeout(this._timer);
-      this._timer = null;
-    }
-    this.startTimer();
-  },
+//   initialCheck: function() {
+//     setTimeout((function () {
+//       this.startCheck(SageUtils.getSageRootFolderId(), true);
+//     }).bind(this), INITIAL_CHECK);
+//   },
+// 
+//   startTimer: function() {
+//     if (this._timer) {
+//       return;
+//     }
+//     setTimeout((function() {
+//       this.startCheck(SageUtils.getSageRootFolderId(), true);
+//       this.resetTimer();
+//     }).bind(this), DELAY);
+//   },
+// 
+//   resetTimer: function() {
+//     if (this._timer) {
+//       clearTimeout(this._timer);
+//       this._timer = null;
+//     }
+//     this.startTimer();
+//   },
 
   /********************************************************
    * Observers


### PR DESCRIPTION
Because I really hate the new auto update feature that was added, I disabled it. This really should have been controlled by a preference value to begin with and have it set to off by default. I commented out the code so that it can be used once the new preference is added.

Signed-off-by: Scott Gustafson scott@garlicsoftware.com
